### PR TITLE
Handle symbol union types correctly

### DIFF
--- a/src/TypeFormatter/PrimitiveUnionTypeFormatter.ts
+++ b/src/TypeFormatter/PrimitiveUnionTypeFormatter.ts
@@ -6,7 +6,6 @@ import type { BaseType } from "../Type/BaseType.js";
 import { BooleanType } from "../Type/BooleanType.js";
 import { NullType } from "../Type/NullType.js";
 import { NumberType } from "../Type/NumberType.js";
-import { PrimitiveType } from "../Type/PrimitiveType.js";
 import { StringType } from "../Type/StringType.js";
 import { UnionType } from "../Type/UnionType.js";
 import { uniqueArray } from "../Utils/uniqueArray.js";
@@ -25,7 +24,13 @@ export class PrimitiveUnionTypeFormatter implements SubTypeFormatter {
     }
 
     protected isPrimitiveUnion(type: UnionType): boolean {
-        return type.getTypes().every((item) => item instanceof PrimitiveType);
+        return type.getTypes().every(
+            (item) =>
+                item instanceof StringType ||
+                item instanceof NumberType ||
+                item instanceof BooleanType ||
+                item instanceof NullType,
+        );
     }
 
     protected getPrimitiveType(item: BaseType): RawTypeName {

--- a/src/TypeFormatter/PrimitiveUnionTypeFormatter.ts
+++ b/src/TypeFormatter/PrimitiveUnionTypeFormatter.ts
@@ -24,13 +24,15 @@ export class PrimitiveUnionTypeFormatter implements SubTypeFormatter {
     }
 
     protected isPrimitiveUnion(type: UnionType): boolean {
-        return type.getTypes().every(
-            (item) =>
-                item instanceof StringType ||
-                item instanceof NumberType ||
-                item instanceof BooleanType ||
-                item instanceof NullType,
-        );
+        return type
+            .getTypes()
+            .every(
+                (item) =>
+                    item instanceof StringType ||
+                    item instanceof NumberType ||
+                    item instanceof BooleanType ||
+                    item instanceof NullType,
+            );
     }
 
     protected getPrimitiveType(item: BaseType): RawTypeName {

--- a/test/valid-data-other.test.ts
+++ b/test/valid-data-other.test.ts
@@ -76,6 +76,7 @@ describe("valid-data-other", () => {
 
     it("symbol", assertValidSchema("symbol", "MyObject"));
     it("unique-symbol", assertValidSchema("unique-symbol", "MyObject"));
+    it("symbol-union", assertValidSchema("symbol-union", "MyObject"));
 
     it("array-min-items-1", assertValidSchema("array-min-items-1", "MyType"));
     it("array-min-items-2", assertValidSchema("array-min-items-2", "MyType"));

--- a/test/valid-data-other.test.ts
+++ b/test/valid-data-other.test.ts
@@ -76,7 +76,7 @@ describe("valid-data-other", () => {
 
     it("symbol", assertValidSchema("symbol", "MyObject"));
     it("unique-symbol", assertValidSchema("unique-symbol", "MyObject"));
-    it("symbol-union", assertValidSchema("symbol-union", "MyObject"));
+    it("symbol-union", assertValidSchema("symbol-union", "MyType"));
 
     it("array-min-items-1", assertValidSchema("array-min-items-1", "MyType"));
     it("array-min-items-2", assertValidSchema("array-min-items-2", "MyType"));

--- a/test/valid-data/symbol-union/main.ts
+++ b/test/valid-data/symbol-union/main.ts
@@ -1,3 +1,1 @@
-export type MyObject = {
-    key: string | symbol;
-};
+export type MyType = string | symbol;

--- a/test/valid-data/symbol-union/main.ts
+++ b/test/valid-data/symbol-union/main.ts
@@ -1,0 +1,3 @@
+export type MyObject = {
+    key: string | symbol;
+};

--- a/test/valid-data/symbol-union/schema.json
+++ b/test/valid-data/symbol-union/schema.json
@@ -1,23 +1,14 @@
 {
-  "$ref": "#/definitions/MyObject",
+  "$ref": "#/definitions/MyType",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
-    "MyObject": {
-      "additionalProperties": false,
-      "properties": {
-        "key": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {}
-          ]
-        }
-      },
-      "required": [
-        "key"
-      ],
-      "type": "object"
+    "MyType": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {}
+      ]
     }
   }
 }

--- a/test/valid-data/symbol-union/schema.json
+++ b/test/valid-data/symbol-union/schema.json
@@ -1,0 +1,23 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "additionalProperties": false,
+      "properties": {
+        "key": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {}
+          ]
+        }
+      },
+      "required": [
+        "key"
+      ],
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- avoid treating symbol unions as primitive unions
- add regression test for `string | symbol` case

## Testing
- `npx jest test/valid-data-other.test.ts -t symbol-union --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_685303817330832d9caa71034e994547