### PR TITLE
Fix re-export pruning when using export all

### DIFF
--- a/src/SchemaGenerator.ts
+++ b/src/SchemaGenerator.ts
@@ -232,10 +232,20 @@ export class SchemaGenerator {
                 return;
             }
 
-            // export { variable } clauses
             if (!node.moduleSpecifier) {
                 return;
             }
+
+            if (node.exportClause) {
+                // export { Foo } from './lib' is handled by visiting specifiers
+                // export * as Foo from './lib' should not import all exports
+                ts.forEachChild(node.exportClause, (subnode) =>
+                    this.inspectNode(subnode, typeChecker, allTypes),
+                );
+                return;
+            }
+
+            // export * from './lib'
 
             const symbol = typeChecker.getSymbolAtLocation(node.moduleSpecifier);
 

--- a/test/valid-data/export-star-prune-unreachable/dep.ts
+++ b/test/valid-data/export-star-prune-unreachable/dep.ts
@@ -1,3 +1,5 @@
 export interface SomeInterface {
     foo?: string;
 }
+
+export type DepType = string;

--- a/test/valid-data/export-star-prune-unreachable/main.ts
+++ b/test/valid-data/export-star-prune-unreachable/main.ts
@@ -1,4 +1,5 @@
 import type { SomeInterface } from "./dep";
+export { DepType } from "./dep";
 
 export type MyType = string;
 

--- a/test/valid-data/export-star-prune-unreachable/schema.json
+++ b/test/valid-data/export-star-prune-unreachable/schema.json
@@ -1,6 +1,9 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+    "DepType": {
+      "type": "string"
+    },
     "MyObject": {
       "additionalProperties": false,
       "properties": {
@@ -18,3 +21,4 @@
     }
   }
 }
+


### PR DESCRIPTION
## Summary
- avoid pulling in the entire module when handling `export { Foo } from './lib'`
- ensure re-exported types are included in `export-star-prune-unreachable`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685435e5fca0832d86ffd86545f997ef