### PR TITLE
Fix export star pruning and re-export detection

### DIFF
--- a/src/SchemaGenerator.ts
+++ b/src/SchemaGenerator.ts
@@ -232,15 +232,14 @@ export class SchemaGenerator {
                 return;
             }
 
-            // export { variable } clauses
-            if (!node.moduleSpecifier) {
+            if (node.exportClause) {
+                // export { Foo } from './lib' or export { Foo };
+                // export * as Foo from './lib' should not import all exports
+                ts.forEachChild(node.exportClause, (subnode) => this.inspectNode(subnode, typeChecker, allTypes));
                 return;
             }
 
-            if (node.exportClause) {
-                // export { Foo } from './lib' is handled by visiting specifiers
-                // export * as Foo from './lib' should not import all exports
-                ts.forEachChild(node.exportClause, (subnode) => this.inspectNode(subnode, typeChecker, allTypes));
+            if (!node.moduleSpecifier) {
                 return;
             }
 


### PR DESCRIPTION
## Summary
- collect root definitions for all exports and prune them
- only process namespaces defined in export clauses
- include local re-exports when collecting types

## Testing
- `npm run test -- test/valid-data-other.test.ts -t "re-export-with-asterisk"`
- `npm run test:fast`

------
https://chatgpt.com/codex/tasks/task_e_6854553a4b6c832d98a677f5aabe9c26