### PR TITLE
Fix mapped type intersections with additional properties

### DIFF
--- a/src/NodeParser/MappedTypeNodeParser.ts
+++ b/src/NodeParser/MappedTypeNodeParser.ts
@@ -10,6 +10,7 @@ import { DefinitionType } from "../Type/DefinitionType.js";
 import type { EnumValue } from "../Type/EnumType.js";
 import { EnumType } from "../Type/EnumType.js";
 import { LiteralType } from "../Type/LiteralType.js";
+import { AnyType } from "../Type/AnyType.js";
 import { NeverType } from "../Type/NeverType.js";
 import { NumberType } from "../Type/NumberType.js";
 import { ObjectProperty, ObjectType } from "../Type/ObjectType.js";
@@ -65,7 +66,10 @@ export class MappedTypeNodeParser implements SubNodeParser {
                 return type instanceof NeverType ? new NeverType() : new ArrayType(type);
             }
             // Key type widens to `string`
-            const type = this.childNodeParser.createType(node.type!, context);
+            const type = this.childNodeParser.createType(
+                node.type!,
+                this.createSubContext(node, keyListType, context),
+            );
             // const resultType = type instanceof NeverType ? new NeverType() : new ObjectType(id, [], [], type);
             const resultType = new ObjectType(id, [], [], type);
             if (resultType) {
@@ -162,13 +166,26 @@ export class MappedTypeNodeParser implements SubNodeParser {
             return this.additionalProperties;
         }
 
-        const key = keyListType.getTypes().filter((type) => !(derefType(type) instanceof LiteralType))[0];
+        const types = keyListType.getTypes();
+        const literalKeys = types.filter((t) => derefType(t) instanceof LiteralType);
+        const nonLiteral = types.filter((type) => !(derefType(type) instanceof LiteralType))[0];
 
-        if (key) {
-            return (
-                this.childNodeParser.createType(node.type!, this.createSubContext(node, key, context)) ??
-                this.additionalProperties
-            );
+        if (nonLiteral) {
+            const additional =
+                this.childNodeParser.createType(
+                    node.type!,
+                    this.createSubContext(node, nonLiteral, context),
+                ) ?? this.additionalProperties;
+
+            if (
+                literalKeys.length > 0 &&
+                additional instanceof AnyType &&
+                this.additionalProperties === true
+            ) {
+                return false;
+            }
+
+            return additional;
         }
 
         return this.additionalProperties;

--- a/src/NodeParser/MappedTypeNodeParser.ts
+++ b/src/NodeParser/MappedTypeNodeParser.ts
@@ -66,10 +66,7 @@ export class MappedTypeNodeParser implements SubNodeParser {
                 return type instanceof NeverType ? new NeverType() : new ArrayType(type);
             }
             // Key type widens to `string`
-            const type = this.childNodeParser.createType(
-                node.type!,
-                this.createSubContext(node, keyListType, context),
-            );
+            const type = this.childNodeParser.createType(node.type!, this.createSubContext(node, keyListType, context));
             // const resultType = type instanceof NeverType ? new NeverType() : new ObjectType(id, [], [], type);
             const resultType = new ObjectType(id, [], [], type);
             if (resultType) {
@@ -172,16 +169,10 @@ export class MappedTypeNodeParser implements SubNodeParser {
 
         if (nonLiteral) {
             const additional =
-                this.childNodeParser.createType(
-                    node.type!,
-                    this.createSubContext(node, nonLiteral, context),
-                ) ?? this.additionalProperties;
+                this.childNodeParser.createType(node.type!, this.createSubContext(node, nonLiteral, context)) ??
+                this.additionalProperties;
 
-            if (
-                literalKeys.length > 0 &&
-                additional instanceof AnyType &&
-                this.additionalProperties === true
-            ) {
+            if (literalKeys.length > 0 && additional instanceof AnyType && this.additionalProperties === true) {
                 return false;
             }
 

--- a/src/NodeParser/TypeOperatorNodeParser.ts
+++ b/src/NodeParser/TypeOperatorNodeParser.ts
@@ -2,7 +2,7 @@ import ts from "typescript";
 import type { Context, NodeParser } from "../NodeParser.js";
 import type { SubNodeParser } from "../SubNodeParser.js";
 import { ArrayType } from "../Type/ArrayType.js";
-import type { BaseType } from "../Type/BaseType.js";
+import { BaseType } from "../Type/BaseType.js";
 import { NumberType } from "../Type/NumberType.js";
 import { ObjectType } from "../Type/ObjectType.js";
 import { StringType } from "../Type/StringType.js";
@@ -28,7 +28,10 @@ export class TypeOperatorNodeParser implements SubNodeParser {
             return new NumberType();
         }
         const keys = getTypeKeys(type);
-        if (derefed instanceof ObjectType && derefed.getAdditionalProperties()) {
+        if (
+            derefed instanceof ObjectType &&
+            derefed.getAdditionalProperties() instanceof BaseType
+        ) {
             return new UnionType([...keys, new StringType()]);
         }
 

--- a/test/config/mapped-intersection-complex/schema.json
+++ b/test/config/mapped-intersection-complex/schema.json
@@ -1,0 +1,21 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "properties": {
+        "bar": {
+          "type": "number"
+        },
+        "foo": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "bar",
+        "foo"
+      ],
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- propagate mapped type keys into subcontexts
- prevent `keyof` from widening when additional properties are only from config
- update schema for `mapped-intersection-complex`

## Testing
- `npm test -- -t "mapped-intersection" --runInBand`
- `npm test -- --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_686a4b9790c0832d8e3847954167e7a4