### PR TITLE
Fix mapped type intersections with additional properties

### DIFF
--- a/src/NodeParser/MappedTypeNodeParser.ts
+++ b/src/NodeParser/MappedTypeNodeParser.ts
@@ -10,6 +10,7 @@ import { DefinitionType } from "../Type/DefinitionType.js";
 import type { EnumValue } from "../Type/EnumType.js";
 import { EnumType } from "../Type/EnumType.js";
 import { LiteralType } from "../Type/LiteralType.js";
+import { AnyType } from "../Type/AnyType.js";
 import { NeverType } from "../Type/NeverType.js";
 import { NumberType } from "../Type/NumberType.js";
 import { ObjectProperty, ObjectType } from "../Type/ObjectType.js";
@@ -65,7 +66,10 @@ export class MappedTypeNodeParser implements SubNodeParser {
                 return type instanceof NeverType ? new NeverType() : new ArrayType(type);
             }
             // Key type widens to `string`
-            const type = this.childNodeParser.createType(node.type!, context);
+            const type = this.childNodeParser.createType(
+                node.type!,
+                this.createSubContext(node, keyListType, context),
+            );
             // const resultType = type instanceof NeverType ? new NeverType() : new ObjectType(id, [], [], type);
             const resultType = new ObjectType(id, [], [], type);
             if (resultType) {
@@ -162,13 +166,26 @@ export class MappedTypeNodeParser implements SubNodeParser {
             return this.additionalProperties;
         }
 
-        const key = keyListType.getTypes().filter((type) => !(derefType(type) instanceof LiteralType))[0];
+        const types = keyListType.getTypes();
+        const literalKeys = types.filter((t) => derefType(t) instanceof LiteralType);
+        const nonLiteral = types.filter((type) => !(derefType(type) instanceof LiteralType))[0];
 
-        if (key) {
-            return (
-                this.childNodeParser.createType(node.type!, this.createSubContext(node, key, context)) ??
-                this.additionalProperties
-            );
+        if (nonLiteral) {
+            const additional =
+                this.childNodeParser.createType(
+                    node.type!,
+                    this.createSubContext(node, nonLiteral, context),
+                ) ?? this.additionalProperties;
+
+            if (
+                literalKeys.length > 0 &&
+                additional instanceof AnyType &&
+                this.additionalProperties === true
+            ) {
+                return false;
+            }
+
+            return additional;
         }
 
         return this.additionalProperties;

--- a/src/NodeParser/TypeOperatorNodeParser.ts
+++ b/src/NodeParser/TypeOperatorNodeParser.ts
@@ -2,7 +2,7 @@ import ts from "typescript";
 import type { Context, NodeParser } from "../NodeParser.js";
 import type { SubNodeParser } from "../SubNodeParser.js";
 import { ArrayType } from "../Type/ArrayType.js";
-import type { BaseType } from "../Type/BaseType.js";
+import { BaseType } from "../Type/BaseType.js";
 import { NumberType } from "../Type/NumberType.js";
 import { ObjectType } from "../Type/ObjectType.js";
 import { StringType } from "../Type/StringType.js";
@@ -28,7 +28,10 @@ export class TypeOperatorNodeParser implements SubNodeParser {
             return new NumberType();
         }
         const keys = getTypeKeys(type);
-        if (derefed instanceof ObjectType && derefed.getAdditionalProperties()) {
+        if (
+            derefed instanceof ObjectType &&
+            derefed.getAdditionalProperties() instanceof BaseType
+        ) {
             return new UnionType([...keys, new StringType()]);
         }
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -407,6 +407,14 @@ describe("config", () => {
     );
 
     it(
+        "mapped-intersection-index",
+        assertSchema("mapped-intersection-index", {
+            type: "MyObject",
+            additionalProperties: true,
+        }),
+    );
+
+    it(
         "arrow-function-parameters",
         assertSchema("arrow-function-parameters", {
             type: "myFunction",

--- a/test/config/mapped-intersection-complex/schema.json
+++ b/test/config/mapped-intersection-complex/schema.json
@@ -1,0 +1,21 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "properties": {
+        "bar": {
+          "type": "number"
+        },
+        "foo": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "bar",
+        "foo"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/test/config/mapped-intersection-index/main.ts
+++ b/test/config/mapped-intersection-index/main.ts
@@ -1,0 +1,11 @@
+interface Base {
+    foo: string;
+    bar: null;
+    [key: string]: any;
+}
+
+type Keep<B, K> = { [P in Exclude<keyof B, K>]: B[P] };
+
+type Override<B, O extends Partial<Record<keyof B, any>>> = Keep<B, keyof O> & O;
+
+export type MyObject = Override<Base, { bar: number }>;

--- a/test/config/mapped-intersection-index/schema.json
+++ b/test/config/mapped-intersection-index/schema.json
@@ -1,0 +1,21 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "properties": {
+        "bar": {
+          "type": "number"
+        },
+        "foo": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "bar",
+        "foo"
+      ],
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- propagate mapped type keys into subcontexts
- avoid widening keyof when additional properties come only from config
- ensure mapped type additionalProperties logic is covered by tests

## Testing
- `npm test -- -t "mapped-intersection-index" --runInBand`
- `npm test -- --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_686a4b9790c0832d8e3847954167e7a4