### PR TITLE
Flatten literal unions across aliases

### DIFF
--- a/src/TypeFormatter/LiteralUnionTypeFormatter.ts
+++ b/src/TypeFormatter/LiteralUnionTypeFormatter.ts
@@ -4,6 +4,8 @@ import type { SubTypeFormatter } from "../SubTypeFormatter.js";
 import type { BaseType } from "../Type/BaseType.js";
 import { EnumType } from "../Type/EnumType.js";
 import { LiteralType, type LiteralValue } from "../Type/LiteralType.js";
+import { AliasType } from "../Type/AliasType.js";
+import { DefinitionType } from "../Type/DefinitionType.js";
 import { NullType } from "../Type/NullType.js";
 import { StringType } from "../Type/StringType.js";
 import { UnionType } from "../Type/UnionType.js";
@@ -21,7 +23,7 @@ export class LiteralUnionTypeFormatter implements SubTypeFormatter {
         let allStrings = true;
         let hasNull = false;
 
-        const literals = unionType.getFlattenedTypes();
+        const literals = unionType.getFlattenedTypes(derefLiteralUnionType);
 
         // filter out String types since we need to be more careful about them
         const types = literals.filter((literal) => {
@@ -76,7 +78,7 @@ export class LiteralUnionTypeFormatter implements SubTypeFormatter {
 
 export function isLiteralUnion(type: UnionType): boolean {
     return type
-        .getFlattenedTypes()
+        .getFlattenedTypes(derefLiteralUnionType)
         .every(
             (item) =>
                 item instanceof LiteralType ||
@@ -84,6 +86,13 @@ export function isLiteralUnion(type: UnionType): boolean {
                 item instanceof StringType ||
                 item instanceof EnumType,
         );
+}
+
+function derefLiteralUnionType(type: BaseType): BaseType {
+    if (type instanceof AliasType || type instanceof DefinitionType) {
+        return derefLiteralUnionType(type.getType());
+    }
+    return type;
 }
 
 /**

--- a/test/valid-data-other.test.ts
+++ b/test/valid-data-other.test.ts
@@ -28,6 +28,7 @@ describe("valid-data-other", () => {
     it("string-literals-intrinsic", assertValidSchema("string-literals-intrinsic", "MyObject"));
     it("string-literals-null", assertValidSchema("string-literals-null", "MyObject"));
     it("string-literals-hack", assertValidSchema("string-literals-hack", "MyObject"));
+    it("string-literals-union-alias", assertValidSchema("string-literals-union-alias", "*"));
     it("string-template-literals", assertValidSchema("string-template-literals", "MyObject"));
     it("string-template-expression-literals", assertValidSchema("string-template-expression-literals", "MyObject"));
     it(

--- a/test/valid-data/string-literals-union-alias/main.ts
+++ b/test/valid-data/string-literals-union-alias/main.ts
@@ -1,0 +1,24 @@
+export type FiasAddressFiasLevel =
+  | '1'
+  | '3'
+  | '4'
+  | '5'
+  | '6'
+  | '65'
+  | '7'
+  | '8';
+
+export type AddressFiasLevel =
+  | '0'
+  | FiasAddressFiasLevel
+  | '75'
+  | '9'
+  | '-1';
+
+export type CleanAddressFiasLevel =
+  | '0'
+  | FiasAddressFiasLevel
+  | '9'
+  | '90'
+  | '91'
+  | '-1';

--- a/test/valid-data/string-literals-union-alias/schema.json
+++ b/test/valid-data/string-literals-union-alias/schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "AddressFiasLevel": {
+      "enum": [
+        "0",
+        "1",
+        "3",
+        "4",
+        "5",
+        "6",
+        "65",
+        "7",
+        "8",
+        "75",
+        "9",
+        "-1"
+      ],
+      "type": "string"
+    },
+    "CleanAddressFiasLevel": {
+      "enum": [
+        "0",
+        "1",
+        "3",
+        "4",
+        "5",
+        "6",
+        "65",
+        "7",
+        "8",
+        "9",
+        "90",
+        "91",
+        "-1"
+      ],
+      "type": "string"
+    },
+    "FiasAddressFiasLevel": {
+      "enum": [
+        "1",
+        "3",
+        "4",
+        "5",
+        "6",
+        "65",
+        "7",
+        "8"
+      ],
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- flatten union enums referenced through exported aliases
- add regression test for alias-based string literal unions

## Testing
- `npm test -- -t "string-literals-union-alias" --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68ab3a3fc530832da2185838ceb8007d