### PR TITLE
Flatten union string literal enums

### DIFF
--- a/src/TypeFormatter/UnionTypeFormatter.ts
+++ b/src/TypeFormatter/UnionTypeFormatter.ts
@@ -120,12 +120,17 @@ export class UnionTypeFormatter implements SubTypeFormatter {
                 flattenedDefinitions.push(def);
             }
         }
+        if (flattenedDefinitions.length > 1) {
+            const merged = this.tryMergeEnums(flattenedDefinitions);
+            if (merged) {
+                return merged;
+            }
+            return {
+                anyOf: flattenedDefinitions,
+            };
+        }
 
-        return flattenedDefinitions.length > 1
-            ? {
-                  anyOf: flattenedDefinitions,
-              }
-            : flattenedDefinitions[0];
+        return flattenedDefinitions[0];
     }
     public getChildren(type: UnionType): BaseType[] {
         return uniqueArray(
@@ -133,5 +138,45 @@ export class UnionTypeFormatter implements SubTypeFormatter {
                 .getTypes()
                 .reduce((result: BaseType[], item) => [...result, ...this.childTypeFormatter.getChildren(item)], []),
         );
+    }
+
+    private tryMergeEnums(defs: JSONSchema7[]): Definition | undefined {
+        if (defs.some((d) => "$ref" in d)) {
+            return undefined;
+        }
+
+        const firstType = defs[0].type;
+        if (typeof firstType !== "string") {
+            return undefined;
+        }
+
+        const values: (string | number | boolean | null)[] = [];
+
+        for (const def of defs) {
+            if (def.type !== firstType) {
+                return undefined;
+            }
+
+            const keys = Object.keys(def);
+            if (keys.some((k) => k !== "type" && k !== "enum" && k !== "const")) {
+                return undefined;
+            }
+
+            if (def.const !== undefined) {
+                if (!values.includes(def.const as any)) {
+                    values.push(def.const as any);
+                }
+            } else if (Array.isArray(def.enum)) {
+                for (const v of def.enum) {
+                    if (!values.includes(v as any)) {
+                        values.push(v as any);
+                    }
+                }
+            } else {
+                return undefined;
+            }
+        }
+
+        return { type: firstType, enum: values };
     }
 }

--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -36,6 +36,7 @@ describe("valid-data-type", () => {
     it("type-regexp", assertValidSchema("type-regexp", "MyObject"));
     it("type-uri", assertValidSchema("type-uri", "MyObject"));
     it("type-union", assertValidSchema("type-union", "TypeUnion"));
+    it("type-union-flatten", assertValidSchema("type-union-flatten", "*"));
     it("type-union-tagged", assertValidSchema("type-union-tagged", "Shape"));
     it("type-intersection", assertValidSchema("type-intersection", "MyObject"));
     it("type-intersection-with-arrays", assertValidSchema("type-intersection-with-arrays", "*"));

--- a/test/valid-data/type-union-flatten/main.ts
+++ b/test/valid-data/type-union-flatten/main.ts
@@ -1,0 +1,5 @@
+type BaseLevel = 'A' | 'B';
+export type ExtendedLevel = 'X' | BaseLevel | 'Y';
+
+export type ExportedBase = 'C' | 'D';
+export type ExtendedWithRef = 'Z' | ExportedBase | 'W';

--- a/test/valid-data/type-union-flatten/schema.json
+++ b/test/valid-data/type-union-flatten/schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "ExportedBase": {
+      "enum": [
+        "C",
+        "D"
+      ],
+      "type": "string"
+    },
+    "ExtendedLevel": {
+      "enum": [
+        "X",
+        "A",
+        "B",
+        "Y"
+      ],
+      "type": "string"
+    },
+    "ExtendedWithRef": {
+      "anyOf": [
+        {
+          "const": "Z",
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/ExportedBase"
+        },
+        {
+          "const": "W",
+          "type": "string"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- merge union members composed of literal enums into a single enum when no `$ref` is present
- add regression test for flattening literal unions and preserving `$ref` unions

## Testing
- `npm run build`
- `npm test -- -t "type-union-flatten"`


------
https://chatgpt.com/codex/tasks/task_e_68ab3a3fc530832da2185838ceb8007d