### PR TITLE
Flatten literal unions with references

### DIFF
--- a/src/TypeFormatter/UnionTypeFormatter.ts
+++ b/src/TypeFormatter/UnionTypeFormatter.ts
@@ -121,11 +121,56 @@ export class UnionTypeFormatter implements SubTypeFormatter {
             }
         }
 
-        return flattenedDefinitions.length > 1
+        const enumGroups = new Map<string, Set<any>>();
+        const otherDefinitions: JSONSchema7[] = [];
+
+        for (const def of flattenedDefinitions) {
+            if (def.$ref !== undefined) {
+                otherDefinitions.push(def);
+                continue;
+            }
+
+            const values: any[] = [];
+            if (def.const !== undefined) {
+                values.push(def.const);
+            }
+            if (def.enum !== undefined) {
+                values.push(...(def.enum as any[]));
+            }
+
+            if (values.length > 0) {
+                const key = JSON.stringify(def.type ?? null);
+                let set = enumGroups.get(key);
+                if (!set) {
+                    set = new Set();
+                    enumGroups.set(key, set);
+                }
+                for (const v of values) {
+                    set.add(v);
+                }
+            } else {
+                otherDefinitions.push(def);
+            }
+        }
+
+        for (const [key, set] of enumGroups.entries()) {
+            const type = JSON.parse(key);
+            const values = Array.from(set);
+            const schema =
+                values.length === 1
+                    ? { const: values[0] }
+                    : { enum: values };
+            if (type !== null) {
+                Object.assign(schema, { type });
+            }
+            otherDefinitions.push(schema as JSONSchema7);
+        }
+
+        return otherDefinitions.length > 1
             ? {
-                  anyOf: flattenedDefinitions,
+                  anyOf: otherDefinitions,
               }
-            : flattenedDefinitions[0];
+            : otherDefinitions[0];
     }
     public getChildren(type: UnionType): BaseType[] {
         return uniqueArray(

--- a/test/valid-data-other.test.ts
+++ b/test/valid-data-other.test.ts
@@ -35,6 +35,8 @@ describe("valid-data-other", () => {
         assertValidSchema("string-template-expression-literals-import", "MyObject"),
     );
 
+    it("string-union-with-ref", assertValidSchema("string-union-with-ref", "*"));
+
     it("namespace-deep-1", assertValidSchema("namespace-deep-1", "RootNamespace.Def"));
     it("namespace-deep-2", assertValidSchema("namespace-deep-2", "RootNamespace.SubNamespace.HelperA"));
     it("namespace-deep-3", assertValidSchema("namespace-deep-3", "RootNamespace.SubNamespace.HelperB"));

--- a/test/valid-data/string-union-with-ref/main.ts
+++ b/test/valid-data/string-union-with-ref/main.ts
@@ -1,0 +1,24 @@
+export type FiasAddressFiasLevel =
+  | '1'
+  | '3'
+  | '4'
+  | '5'
+  | '6'
+  | '65'
+  | '7'
+  | '8';
+
+export type AddressFiasLevel =
+  | '0'
+  | FiasAddressFiasLevel
+  | '75'
+  | '9'
+  | '-1';
+
+export type CleanAddressFiasLevel =
+  | '0'
+  | FiasAddressFiasLevel
+  | '9'
+  | '90'
+  | '91'
+  | '-1';

--- a/test/valid-data/string-union-with-ref/schema.json
+++ b/test/valid-data/string-union-with-ref/schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "AddressFiasLevel": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/FiasAddressFiasLevel"
+        },
+        {
+          "enum": [
+            "0",
+            "75",
+            "9",
+            "-1"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "CleanAddressFiasLevel": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/FiasAddressFiasLevel"
+        },
+        {
+          "enum": [
+            "0",
+            "9",
+            "90",
+            "91",
+            "-1"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "FiasAddressFiasLevel": {
+      "enum": [
+        "1",
+        "3",
+        "4",
+        "5",
+        "6",
+        "65",
+        "7",
+        "8"
+      ],
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- collapse literal members in unions into a single enum while retaining `$ref` entries
- add regression test for unions mixing literal strings with referenced enums

## Testing
- `npm test -- -t "string-union-with-ref" --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68ab3a3fc530832da2185838ceb8007d